### PR TITLE
fix: ensure quiz modal overlays topmost on mobile

### DIFF
--- a/docs/assets/css/kits.css
+++ b/docs/assets/css/kits.css
@@ -584,15 +584,15 @@ details.facet[open] .chev{ transform: rotate(180deg); color: var(--primary); }
   margin: 0;
   border: none;
   background: transparent;            /* visuals live on the panel */
-  z-index: 160;
+  z-index: 1001;               /* above any site overlay */
 
   /* Neutralize legacy centering that could fight UA defaults */
   top: auto; left: auto; transform: none;
 
   /* Full-viewport overlay area */
-  width: 100vw;
-  height: 100vh;
-  max-height: 100vh;
+  width: 100dvw;
+  height: 100dvh;
+  max-height: 100dvh;
 
   /* Hidden by default. Shown only when [open] or .is-open */
   display: none;
@@ -613,7 +613,7 @@ dialog.modal:not([open]):not(.is-open){ display: none !important; }
 .modal .modal-content{
   display: grid;
   grid-template-rows: auto 1fr auto;
-  width: min(95vw, 900px);
+  width: min(95dvw, 900px);
   max-height: 95vh;
   min-height: 600px;
 
@@ -778,9 +778,9 @@ dialog.modal:not([open]):not(.is-open){ display: none !important; }
 @media (max-width: 640px){
   .modal{ padding: 0; }
   .modal .modal-content{
-    width: 100vw;
-    height: 100vh;
-    max-height: 100vh;
+    width: 100dvw;
+    height: 100dvh;
+    max-height: 100dvh;
     border-radius: 0;
   }
 }
@@ -804,7 +804,7 @@ dialog.modal:not([open]):not(.is-open){ display: none !important; }
   .search-container{ flex-direction: column; align-items: stretch; }
   .search-wrapper{ min-width: auto; }
   .product-grid{ grid-template-columns: repeat(auto-fit, minmax(280px,1fr)); gap: var(--space-4); }
-  .modal{ width:95vw; height:95vh; max-height:95vh; }
+  .modal{ width:95dvw; height:95dvh; max-height:95dvh; }
   .quiz-progress{ flex-wrap:wrap; gap: var(--space-2); }
   .speed-grid{ grid-template-columns: repeat(auto-fit, minmax(100px,1fr)); }
 }
@@ -828,7 +828,7 @@ dialog.modal:not([open]):not(.is-open){ display: none !important; }
   .quick-btn{ width:40px; height:40px; font-size: var(--text-sm); }
   .fab{ bottom: var(--space-4); right: var(--space-4); padding: var(--space-2) var(--space-3); font-size: var(--text-xs); }
   .drawer-panel{ padding: var(--space-3); border-radius: var(--radius-lg) var(--radius-lg) 0 0; }
-  .modal{ width:100vw; height:100vh; max-height:100vh; border-radius:0; transform:none; top:0; left:0; }
+  .modal{ width:100dvw; height:100dvh; max-height:100dvh; border-radius:0; transform:none; top:0; left:0; }
   .modal-header{ padding: var(--space-4); }
   .quiz-body{ padding: var(--space-4); gap: var(--space-4); }
   .quiz-progress{ padding: var(--space-3); flex-direction: column; gap: var(--space-2); align-items: stretch; }
@@ -936,16 +936,29 @@ dialog.modal:not([open]):not(.is-open){ display: none !important; }
 .compare-sticky{ z-index:120; }
 .compare{ z-index:130; }
 .drawer{ z-index:150; }
-.modal{ z-index:160; }
+.modal{ z-index:1001; }
 .page-progress-ring{ z-index:200; }
 
 /* Fallback backdrop for non-top-layer dialogs */
 #quizBackdrop {
   position: fixed;
   inset: 0;
+  width: 100dvw;
+  height: 100dvh;
   background: rgba(0,0,0,.8);
   backdrop-filter: blur(12px);
-  z-index: 155;          /* below .modal (160), above page */
+  z-index: 1000;          /* just under .modal */
   display: none;
+}
+
+/* Body lock and overlay suppression when quiz is open */
+html.is-quiz-open,
+body.is-quiz-open {
+  overflow: hidden;
+}
+body.is-quiz-open .overlay,
+body.is-quiz-open .drawer {
+  display: none !important;
+  pointer-events: none !important;
 }
 

--- a/docs/assets/js/quiz-modal.js
+++ b/docs/assets/js/quiz-modal.js
@@ -104,6 +104,17 @@
     dlg.classList.add('is-open');
     // lock background scroll for both modes
     document.documentElement.style.overflow = 'hidden';
+    document.documentElement.classList.add('is-quiz-open');
+    document.body.classList.add('is-quiz-open');
+
+    // ensure other overlays/drawers are suppressed
+    document.getElementById('sidebar-overlay')?.classList.remove('active');
+    document.getElementById('sidebar')?.classList.remove('active');
+    document.getElementById('sidebar')?.setAttribute('aria-hidden','true');
+    document.getElementById('hamburger-menu')?.classList.remove('active');
+    document.getElementById('hamburger-menu')?.setAttribute('aria-expanded','false');
+    document.getElementById('filtersDrawer')?.setAttribute('aria-hidden','true');
+    document.documentElement.classList.remove('scroll-lock');
 
     queueMicrotask(() => firstFocusable(dlg)?.focus());
     attachTrap();
@@ -116,6 +127,8 @@
 
     // unlock background scroll
     document.documentElement.style.overflow = '';
+    document.documentElement.classList.remove('is-quiz-open');
+    document.body.classList.remove('is-quiz-open');
 
     // hide fallback backdrop
     fbBackdrop.style.display = 'none';


### PR DESCRIPTION
## Summary
- raise quiz modal/backdrop z-index and switch to dynamic viewport units to prevent off-screen overlays
- hide sidebar/filter overlays and lock scroll via new `is-quiz-open` body class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba359d1148832f99702f70bc42b6b8